### PR TITLE
adding GKE module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,3 +53,8 @@ module "lightstep_pubsub_dashboard" {
   source            = "./modules/pubsub"
   lightstep_project = var.lightstep_project
 }
+
+module "lightstep_kubernetes_dashboard" {
+  source            = "./modules/kubernetes"
+  lightstep_project = var.lightstep_project
+}

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    lightstep = {
+      source  = "lightstep/lightstep"
+      version = "1.60.1"
+    }
+  }
+  required_version = ">= v1.1.0"
+}
+
+resource "lightstep_metric_dashboard" "kubernetes_dashboard" {
+  project_name   = var.lightstep_project
+  dashboard_name = "Kubernetes Metric Dashboards"
+
+  chart {
+    name = "GCP Kubernetes Container Req Utilization"
+    rank = "0"
+    type = "timeseries"
+
+    query {
+      query_name = "a"
+      display    = "line"
+      hidden     = false
+
+      metric              = "kubernetes.io/container/request_utilization"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = ["container_id", ]
+      }
+
+    }
+
+  }
+
+}

--- a/modules/kubernetes/outputs.tf
+++ b/modules/kubernetes/outputs.tf
@@ -1,0 +1,4 @@
+output "dashboard_url" {
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_metric_dashboard.kubernetes_dashboard.id}"
+  description = "SNS Dashboard URL"
+}

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -1,0 +1,5 @@
+variable "lightstep_project" {
+  description = "Name of Lightstep project"
+  type        = string
+  default     = "terraform-shop"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "lightstep_pubsub_dashboard_url" {
   value       = module.lightstep_pubsub_dashboard.dashboard_url
   description = "Lightstep GCP Bigtable Dashboard URL"
 }
+
+output "lightstep_kubernetes_dashboard_url" {
+  value       = module.lightstep_kubernetes_dashboard.dashboard_url
+  description = "Lightstep GCP Bigtable Dashboard URL"
+}


### PR DESCRIPTION
What Does This PR Do?
This PR adds a GKE module to our GCP terraform dashboards

Why Are You Doing It?
This adds a module for a commonly used dashboard so that customers can easily manage Kubernetes clusters.